### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Amour.php
+++ b/src/Amour.php
@@ -95,7 +95,7 @@ class Amour extends Plugin
 
 
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new AmourTwigExtension());
+        Craft::$app->view->registerTwigExtension(new AmourTwigExtension());
 
         // Add in our console commands
         if (Craft::$app instanceof ConsoleApplication) {


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.